### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,10 @@ exports.extract = function (cwd, opts) {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
         var srcpath = path.resolve(cwd, header.linkname)
+        if (!srcpath.startsWith(cwd)) {
+          console.log('Skipping unsafe linkname:', header.linkname)
+          return next()
+        }
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {


### PR DESCRIPTION
Potential fix for [https://github.com/FRNKUSD/code-scanning-javascript-demo/security/code-scanning/1](https://github.com/FRNKUSD/code-scanning-javascript-demo/security/code-scanning/1)

To fix the issue, we need to validate `header.linkname` to ensure it does not contain directory traversal elements (`..`) or other unsafe characters before using it in a filesystem operation. The best approach is to check if the resolved path remains within the intended directory (`cwd`) after combining it with `header.linkname`. This ensures that malicious paths attempting to escape the target directory are blocked.

Steps to implement the fix:
1. Add a validation step for `header.linkname` before constructing `srcpath`.
2. Use a helper function to ensure the resolved path is within the `cwd` directory.
3. If the validation fails, log the issue and skip processing the entry.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
